### PR TITLE
Sharing a challenge with a non-existant user should generate and return that new user

### DIFF
--- a/src/main/helpers/UserAccountHelper.kt
+++ b/src/main/helpers/UserAccountHelper.kt
@@ -1,0 +1,58 @@
+package main.helpers
+
+import framework.models.idValue
+import kotlinserverless.framework.services.SOAResult
+import kotlinserverless.framework.services.SOAResultType
+import main.daos.*
+import main.services.user_account.GenerateUserAccountService
+
+object UserAccountHelper {
+    fun getOrGenerateUserToShareWith(
+        emailToShareWith: String?,
+        publicKeyToShareWith: String?
+    ): SOAResult<Pair<String, NewUserAccount?>> {
+        // validate users exist, if it does not generate one
+        var newUserAccount: NewUserAccount? = null
+
+        // get the public key we need to share with
+        val publicKeyToShareWith = when {
+            /** if the email is provided make sure the user exists
+             *   if the user does not exist we need to generate it
+             *   if the email is not provided and the user does not exist we should error
+             *   in order to share with a non-existant user we must have the email
+             **/
+            emailToShareWith != null -> {
+                val userResult = User.find {
+                    Users.email eq emailToShareWith
+                }
+                val userAccount = if(userResult.empty()) {
+                    val newUserAccountResult = GenerateUserAccountService.execute(
+                        uemail = emailToShareWith,
+                        ufirstname = emailToShareWith.substringBefore("@"),
+                        ulastname = ""
+                    )
+
+                    if(newUserAccountResult.result != SOAResultType.SUCCESS)
+                        return SOAResult(newUserAccountResult.result, newUserAccountResult.message)
+                    newUserAccount = newUserAccountResult.data
+                    newUserAccount!!.value
+                } else {
+                    UserAccount.find {
+                        UserAccounts.userMetadata eq userResult.first().id
+                    }.first()
+                }
+
+                userAccount.cryptoKeyPair.publicKey
+            }
+            publicKeyToShareWith != null -> {
+                val keyPair = CryptoKeyPair.find { CryptoKeyPairs.publicKey eq publicKeyToShareWith }
+                if(keyPair.empty())
+                    return SOAResult(SOAResultType.FAILURE, "The user does not exist. In order to share with that user you must share via email.")
+                publicKeyToShareWith
+            }
+            else ->
+                return SOAResult(SOAResultType.FAILURE, "Must include an email or public key to share with")
+        }
+        return SOAResult(SOAResultType.SUCCESS, null, Pair(publicKeyToShareWith, newUserAccount))
+    }
+}

--- a/src/main/services/challenge/ShareChallengeService.kt
+++ b/src/main/services/challenge/ShareChallengeService.kt
@@ -4,91 +4,80 @@ import framework.models.idValue
 import kotlinserverless.framework.services.SOAResult
 import kotlinserverless.framework.services.SOAResultType
 import main.daos.*
+import main.helpers.UserAccountHelper
 import main.services.transaction.GenerateTransactionService
 import main.services.transaction.GetTransactionsService
+import main.services.user_account.GenerateUserAccountService
+import org.jetbrains.exposed.sql.select
 import org.joda.time.DateTime
 
 /**
  * Share a challenge.
  */
 object ShareChallengeService {
-    fun execute(caller: UserAccount, challenge: Challenge, publicKeyToShareWith: String, shares: Int, expiration: String?) : SOAResult<TransactionList> {
-//            val keyPairToShareWith = CryptoKeyPair.find { CryptoKeyPairs.publicKey eq publicKeyToShareWith }.first()
-//            val userToShareWith = UserAccount.find {
-//                UserAccounts.cryptoKeyPair eq keyPairToShareWith.idValue
-//            }.first()
+    fun execute(
+        caller: UserAccount,
+        challenge: Challenge,
+        shares: Int,
+        publicKeyToShareWith: String? = null,
+        emailToShareWith: String? = null,
+        expiration: String? = null
+    ) : SOAResult<Pair<TransactionList, NewUserAccount?>> {
 
-        // validate users exist
+        // Validate user exists or attempt to generate a new user
+        val userAccountToShareWithInformation = UserAccountHelper.getOrGenerateUserToShareWith(emailToShareWith, publicKeyToShareWith)
+        val(publicKeyToShareWith, newUserAccount) = if(userAccountToShareWithInformation.result != SOAResultType.SUCCESS)
+            return SOAResult(userAccountToShareWithInformation.result, userAccountToShareWithInformation.message)
+        else
+            userAccountToShareWithInformation.data!!
+
         // TODO look into using a datetime formatter
         val expiration = expiration ?: challenge.challengeSettings.shareExpiration.toString()
 
-        // if on chain -- validate the user has enough shares
-        if(!challenge.challengeSettings.offChain) {
-            val sharabilityResult = ValidateShareService.execute(caller, challenge, shares)
+        return if(!challenge.challengeSettings.offChain)
+            shareOnChain(caller, challenge, shares, publicKeyToShareWith, expiration, newUserAccount)
+        else
+            shareOffChain(caller, challenge, shares, publicKeyToShareWith, expiration, newUserAccount)
+    }
 
-            if(sharabilityResult.result != SOAResultType.SUCCESS || !sharabilityResult.data!!.first)
-                return SOAResult(SOAResultType.FAILURE, sharabilityResult.message)
+    private fun shareOnChain(
+        caller: UserAccount,
+        challenge: Challenge,
+        shares: Int,
+        publicKeyToShareWith: String,
+        expiration: String,
+        newUserAccount: NewUserAccount?
+    ): SOAResult<Pair<TransactionList, NewUserAccount?>> {
 
-            val unsharedTransactions = sharabilityResult.data!!.second!!
+        // validate the user has enough shares
+        // check that we can share based on # shares available and attempt
+        val sharabilityResult = ValidateShareService.execute(caller, challenge, shares)
 
-            // loop sharing new tx until all spent that is needed
-            // TODO look into partial share -- if one tx fails what happens
-            var txs = mutableListOf<Transaction>()
-            var shared = 0
-            unsharedTransactions.transactionsToShares.forEach {
-                if(shared >= shares)
-                    return@forEach
-                val ustx = it.first
-                val amount = it.second
+        if(sharabilityResult.result != SOAResultType.SUCCESS || !sharabilityResult.data!!.first)
+            return SOAResult(SOAResultType.FAILURE, sharabilityResult.message)
 
-                val txResult = GenerateTransactionService.execute(TransactionNamespace(
-                    from = caller.cryptoKeyPair.publicKey,
-                    to = publicKeyToShareWith,
-                    previousTransaction = ustx.idValue,
-                    metadatas = MetadatasListNamespace(
-                        ChallengeMetadata(
-                            challenge.idValue,
-                            challenge.challengeSettings.offChain,
-                            expiration,
-                            Math.min(shares, amount)
-                        ).getChallengeMetadataNamespaces()
-                    ),
-                    action = ActionNamespace(
-                        type = ActionType.SHARE,
-                        data = challenge.idValue,
-                        dataType = Challenge::class.simpleName!!
-                    )
-                ))
+        val unsharedTransactions = sharabilityResult.data!!.second!!
 
-                // TODO decide what to do if the txresult fails
-                txs.add(txResult.data!!)
-                shared += amount
-            }
-            return SOAResult(SOAResultType.SUCCESS, null, TransactionList(txs))
-        } else {
-            // create a tx using previous as the first tx
-            val receivedTransactionResult = GetTransactionsService.execute(
-                null,
-                caller.cryptoKeyPair.publicKey,
-                null,
-                ActionNamespace(ActionType.SHARE, challenge.idValue, "Challenge")
-            )
-
-            if(receivedTransactionResult.result != SOAResultType.SUCCESS)
-                return SOAResult(SOAResultType.FAILURE, receivedTransactionResult.message)
-
-            val previousTx = receivedTransactionResult.data!!.transactions?.first()
+        // loop sharing new tx until all spent that is needed
+        // TODO look into partial share -- if one tx fails what happens
+        var txs = mutableListOf<Transaction>()
+        var shared = 0
+        unsharedTransactions.transactionsToShares.forEach {
+            if(shared >= shares)
+                return@forEach
+            val ustx = it.first
+            val amount = it.second
 
             val txResult = GenerateTransactionService.execute(TransactionNamespace(
                 from = caller.cryptoKeyPair.publicKey,
                 to = publicKeyToShareWith,
-                previousTransaction = previousTx?.idValue,
+                previousTransaction = ustx.idValue,
                 metadatas = MetadatasListNamespace(
                     ChallengeMetadata(
                         challenge.idValue,
                         challenge.challengeSettings.offChain,
                         expiration,
-                        shares ?: challenge.challengeSettings.maxSharesPerReceivedShare
+                        Math.min(shares, amount)
                     ).getChallengeMetadataNamespaces()
                 ),
                 action = ActionNamespace(
@@ -98,9 +87,55 @@ object ShareChallengeService {
                 )
             ))
 
-            if(txResult.result != SOAResultType.SUCCESS)
-                return SOAResult(SOAResultType.FAILURE, txResult.message)
-            return SOAResult(SOAResultType.SUCCESS, null, TransactionList(listOf(txResult.data!!)))
+            // TODO decide what to do if the txresult fails
+            txs.add(txResult.data!!)
+            shared += amount
         }
+        return SOAResult(SOAResultType.SUCCESS, null, Pair(TransactionList(txs), newUserAccount))
+    }
+
+    private fun shareOffChain(
+        caller: UserAccount,
+        challenge: Challenge,
+        shares: Int,
+        publicKeyToShareWith: String,
+        expiration: String,
+        newUserAccount: NewUserAccount?
+    ): SOAResult<Pair<TransactionList, NewUserAccount?>> {
+        // create a tx using previous as the first tx
+        val receivedTransactionResult = GetTransactionsService.execute(
+            null,
+            caller.cryptoKeyPair.publicKey,
+            null,
+            ActionNamespace(ActionType.SHARE, challenge.idValue, "Challenge")
+        )
+
+        if(receivedTransactionResult.result != SOAResultType.SUCCESS)
+            return SOAResult(SOAResultType.FAILURE, receivedTransactionResult.message)
+
+        val previousTx = receivedTransactionResult.data!!.transactions?.first()
+
+        val txResult = GenerateTransactionService.execute(TransactionNamespace(
+            from = caller.cryptoKeyPair.publicKey,
+            to = publicKeyToShareWith,
+            previousTransaction = previousTx?.idValue,
+            metadatas = MetadatasListNamespace(
+                ChallengeMetadata(
+                    challenge.idValue,
+                    challenge.challengeSettings.offChain,
+                    expiration,
+                    shares
+                ).getChallengeMetadataNamespaces()
+            ),
+            action = ActionNamespace(
+                type = ActionType.SHARE,
+                data = challenge.idValue,
+                dataType = Challenge::class.simpleName!!
+            )
+        ))
+
+        if(txResult.result != SOAResultType.SUCCESS)
+            return SOAResult(SOAResultType.FAILURE, txResult.message)
+        return SOAResult(SOAResultType.SUCCESS, null, Pair(TransactionList(listOf(txResult.data!!)), newUserAccount))
     }
 }

--- a/src/test/unit/services/challenge/CompleteChallengeServiceTest.kt
+++ b/src/test/unit/services/challenge/CompleteChallengeServiceTest.kt
@@ -55,9 +55,8 @@ class CompleteChallengeServiceTest : WordSpec() {
                     ShareChallengeService.execute(
                         userAccount1,
                         challenge,
-                        userAccount2.cryptoKeyPair.publicKey,
                         50,
-                        null
+                        userAccount2.cryptoKeyPair.publicKey
                     )
                     /**
                      *          user1 (20)
@@ -67,9 +66,8 @@ class CompleteChallengeServiceTest : WordSpec() {
                     ShareChallengeService.execute(
                         userAccount1,
                         challenge,
-                        userAccount2.cryptoKeyPair.publicKey,
                         30,
-                        null
+                        userAccount2.cryptoKeyPair.publicKey
                     )
                     /**
                      *          user1 (20)
@@ -81,9 +79,8 @@ class CompleteChallengeServiceTest : WordSpec() {
                     ShareChallengeService.execute(
                         userAccount2,
                         challenge,
-                        userAccount3.cryptoKeyPair.publicKey,
                         80,
-                        null
+                        userAccount3.cryptoKeyPair.publicKey
                     )
 
                     // user 2 should not be able to complete the challenge

--- a/src/test/unit/services/challenge/ShareChallengeServiceTest.kt
+++ b/src/test/unit/services/challenge/ShareChallengeServiceTest.kt
@@ -46,15 +46,40 @@ class ShareChallengeServiceTest : WordSpec() {
                     val result = ShareChallengeService.execute(
                         userAccount1,
                         challenge,
-                        userAccount2.cryptoKeyPair.publicKey,
                         50,
-                        null
+                        userAccount2.cryptoKeyPair.publicKey
                     )
                     result.result shouldBe SOAResultType.SUCCESS
-                    result.data!!.transactions.count() shouldBe 1
+                    result.data!!.first.transactions.count() shouldBe 1
 
                     val result2 = GetUnsharedTransactionsService.execute(userAccount1, challenge.idValue)
                     result2.data!!.transactionsToShares.map { it.second }.sum() shouldBe 50
+                }
+            }
+            "if the user does not exist and an email is passed, generate a single transaction sharing to a new user" {
+                transaction {
+                    val result = ShareChallengeService.execute(
+                        userAccount1,
+                        challenge,
+                        50,
+                        null,
+                        "newuseremail@okgo.com"
+                    )
+                    result.result shouldBe SOAResultType.SUCCESS
+                    result.data!!.first.transactions.count() shouldBe 1
+                    result.data!!.second!!.value.userMetadata.email shouldBe "newuseremail@okgo.com"
+                }
+            }
+            "if the user does not exist and no email is passed, fail" {
+                transaction {
+                    val result = ShareChallengeService.execute(
+                        userAccount1,
+                        challenge,
+                        50,
+                        "SOMEFAKEPUBLICKEY"
+                    )
+                    result.result shouldBe SOAResultType.FAILURE
+                    result.message shouldBe "The user does not exist. In order to share with that user you must share via email."
                 }
             }
         }
@@ -65,16 +90,14 @@ class ShareChallengeServiceTest : WordSpec() {
                     ShareChallengeService.execute(
                         userAccount1,
                         challenge,
-                        userAccount2.cryptoKeyPair.publicKey,
                         50,
-                        null
+                        userAccount2.cryptoKeyPair.publicKey
                     )
                     ShareChallengeService.execute(
                         userAccount1,
                         challenge,
-                        userAccount2.cryptoKeyPair.publicKey,
                         30,
-                        null
+                        userAccount2.cryptoKeyPair.publicKey
                     )
                     val result2 = GetUnsharedTransactionsService.execute(userAccount1, challenge.idValue)
                     result2.data!!.transactionsToShares.map { it.second }.sum() shouldBe 20
@@ -82,20 +105,18 @@ class ShareChallengeServiceTest : WordSpec() {
                     var result = ShareChallengeService.execute(
                         userAccount2,
                         challenge,
-                        userAccount3.cryptoKeyPair.publicKey,
                         90,
-                        null
+                        userAccount3.cryptoKeyPair.publicKey
                     )
                     result.result shouldBe SOAResultType.FAILURE
                     result = ShareChallengeService.execute(
                         userAccount2,
                         challenge,
-                        userAccount3.cryptoKeyPair.publicKey,
                         80,
-                        null
+                        userAccount3.cryptoKeyPair.publicKey
                     )
                     result.result shouldBe SOAResultType.SUCCESS
-                    result.data!!.transactions.count() shouldBe 2
+                    result.data!!.first.transactions.count() shouldBe 2
 
                     val result3 = GetUnsharedTransactionsService.execute(userAccount3, challenge.idValue)
                     result3.data!!.transactionsToShares.map { it.second }.sum() shouldBe 80
@@ -108,9 +129,8 @@ class ShareChallengeServiceTest : WordSpec() {
                     val result = ShareChallengeService.execute(
                         userAccount1,
                         challenge,
-                        userAccount2.cryptoKeyPair.publicKey,
                         2000,
-                        null
+                        userAccount2.cryptoKeyPair.publicKey
                     )
                     result.result shouldBe SOAResultType.FAILURE
                 }
@@ -129,9 +149,8 @@ class ShareChallengeServiceTest : WordSpec() {
                     val result = ShareChallengeService.execute(
                         userAccount1,
                         challenge,
-                        userAccount2.cryptoKeyPair.publicKey,
                         1,
-                        null
+                        userAccount2.cryptoKeyPair.publicKey
                     )
                     result.result shouldBe SOAResultType.FAILURE
                 }


### PR DESCRIPTION
Allow users to share to emails that are not yet users. 

Currently will error out for non-existant public keys

Restructured the share service so it is cleaner, has many methods now. Also added a helper class and method to handle generating a new user if it doesnt exist.