### PR TITLE
Separate redepmption logic from completion logic...make efficiency upgrades...and better testing.

### DIFF
--- a/src/main/services/challenge/CompleteChallengeService.kt
+++ b/src/main/services/challenge/CompleteChallengeService.kt
@@ -11,17 +11,7 @@ import main.services.reward.DistributeRewardService
  * Trigger a challenge state change to active.
  */
 object CompleteChallengeService {
-    fun execute(caller: UserAccount, params: Map<String, String>?) : SOAResult<TransactionList> {
-        val challenge = Challenge.findById(params!!["challengeId"]!!.toInt())!!
-
-        // check if the completion criteria matches.
-        val validationResult = ValidateCompletionCriteriaService.execute(
-            caller,
-            challenge.completionCriterias
-        )
-        if(validationResult.result != SOAResultType.SUCCESS)
-            return SOAResult(SOAResultType.FAILURE, validationResult.message)
-
+    fun execute(caller: UserAccount, challenge: Challenge, completerPublicKey: String) : SOAResult<TransactionList> {
         // validate we can do the state transition
         val newState = ActionType.valueOf("COMPLETE")
         val oldTx = challenge.getLastStateChangeTransaction()!!
@@ -29,37 +19,17 @@ object CompleteChallengeService {
         if(!challenge.canTransitionState(oldState, newState))
             return SOAResult(SOAResultType.FAILURE, "Cannot transition from ${oldState.type} to ${newState.type}")
 
-        // validate user has any shares available -- without any they cannot complete
-        val completingUserPublicKey = params!!["completingUserPublicKey"]!!
-        val completingKeyPair = CryptoKeyPair.find { CryptoKeyPairs.publicKey eq completingUserPublicKey }.first()
-        val userToCompleteWith = UserAccount.find {
-            UserAccounts.cryptoKeyPair eq completingKeyPair.idValue
-        }.first()
+        // Redeem challenge
+        val redemptionResult = RedeemChallengeService.execute(caller, challenge, completerPublicKey)
 
-        val sharabilityResult = ValidateShareService.execute(userToCompleteWith, challenge)
-
-        if(sharabilityResult.result != SOAResultType.SUCCESS)
-            return SOAResult(SOAResultType.FAILURE, sharabilityResult.message)
-
-        if(!sharabilityResult.data!!.first)
-            return SOAResult(SOAResultType.FAILURE, "User must have a share in order to complete")
-
-        val unsharedTransactions = sharabilityResult.data!!.second!!
+        if(redemptionResult.result != SOAResultType.SUCCESS)
+            return redemptionResult
 
         // transition state
         val stateChangeResult = ChangeChallengeStateService.execute(caller, challenge.idValue, ActionType.COMPLETE)
         if(stateChangeResult.result != SOAResultType.SUCCESS)
             return SOAResult(SOAResultType.FAILURE, stateChangeResult.message)
 
-        // decide which transaction to use ( TODO for now the first unshared tx?)
-        val firstUnspentTx = unsharedTransactions.transactionsToShares.first().first.idValue
-
-        // TODO: generate a tx moving the share to the completion contract
-
-        // payout winner
-        return DistributeRewardService.execute(
-            challenge.completionCriterias.reward.idValue,
-            firstUnspentTx
-        )
+        return redemptionResult
     }
 }

--- a/src/main/services/challenge/RedeemChallengeService.kt
+++ b/src/main/services/challenge/RedeemChallengeService.kt
@@ -1,0 +1,75 @@
+package main.services.challenge
+
+import framework.models.idValue
+import kotlinserverless.framework.services.SOAResult
+import kotlinserverless.framework.services.SOAResultType
+import main.daos.*
+import main.services.completion_criteria.ValidateCompletionCriteriaService
+import main.services.reward.DistributeRewardService
+import main.services.transaction.GenerateTransactionService
+
+/**
+ * Redeem a challenge to complete a single providence chain
+ */
+object RedeemChallengeService {
+    fun execute(caller: UserAccount, challenge: Challenge, completerPublicKey: String) : SOAResult<TransactionList> {
+        // TODO -- we should check for the caller if they should be calling CompleteChallengeService instead
+        // TODO ^ -- if the max completers has been met by this call we should complete the challenge
+        // check if the completion criteria matches.
+        val validationResult = ValidateCompletionCriteriaService.execute(
+            caller,
+            challenge.completionCriterias
+        )
+        if(validationResult.result != SOAResultType.SUCCESS)
+            return SOAResult(SOAResultType.FAILURE, validationResult.message)
+
+        // validate user has any shares available -- without any they cannot complete
+        val completingKeyPair = CryptoKeyPair.find { CryptoKeyPairs.publicKey eq completerPublicKey }.first()
+        val userToCompleteWith = UserAccount.find {
+            UserAccounts.cryptoKeyPair eq completingKeyPair.idValue
+        }.first()
+
+        val sharabilityResult = ValidateShareService.execute(userToCompleteWith, challenge)
+
+        if(sharabilityResult.result != SOAResultType.SUCCESS)
+            return SOAResult(SOAResultType.FAILURE, sharabilityResult.message)
+
+        if(!sharabilityResult.data!!.first)
+            return SOAResult(SOAResultType.FAILURE, "User must have a share in order to complete")
+
+        val unsharedTransactions = sharabilityResult.data!!.second!!
+
+        // decide which transaction to use ( TODO for now the first unshared tx?)
+        val firstUnspentTx = unsharedTransactions.transactionsToShares.first().first
+
+        // TODO test this gets generated correctly
+        // generate a tx moving the share to the completion contract so it cannot be used again
+        val txResult = GenerateTransactionService.execute(TransactionNamespace(
+            from = completerPublicKey,
+            to = challenge.completionCriterias.address,
+            previousTransaction = firstUnspentTx.idValue,
+            metadatas = MetadatasListNamespace(
+                ChallengeMetadata(
+                    challenge.idValue,
+                    challenge.challengeSettings.offChain,
+                    challenge.challengeSettings.shareExpiration.toString(),
+                    1
+                ).getChallengeMetadataNamespaces()
+            ),
+            action = ActionNamespace(
+                type = ActionType.SHARE,
+                data = challenge.idValue,
+                dataType = Challenge::class.simpleName!!
+            )
+        ))
+
+        if(txResult.result != SOAResultType.SUCCESS)
+            return SOAResult(SOAResultType.FAILURE, txResult.message)
+
+        // payout winner
+        return DistributeRewardService.execute(
+            challenge.completionCriterias.reward,
+            firstUnspentTx
+        )
+    }
+}

--- a/src/main/services/reward/DistributeRewardService.kt
+++ b/src/main/services/reward/DistributeRewardService.kt
@@ -10,8 +10,7 @@ import main.services.transaction.GetProvidenceChainService
  * Transfer tokens based on rewards
  */
 object DistributeRewardService {
-    fun execute(rewardId: Int, transactionId: Int) : SOAResult<TransactionList> {
-        val reward = Reward.findById(rewardId)!!
+    fun execute(reward: Reward, transaction: Transaction) : SOAResult<TransactionList> {
         val address = reward.pool.cryptoKeyPair.publicKey
 
         // calculate rewards
@@ -25,7 +24,7 @@ object DistributeRewardService {
 
         //TODO what should we do if any of the balances are negative but some are positive?
         //TODO handle 'ALL' type reward audience -- get all chains
-        val providenceChainResult = GetProvidenceChainService.execute(transactionId)
+        val providenceChainResult = GetProvidenceChainService.execute(transaction)
         if(providenceChainResult.result != SOAResultType.SUCCESS)
             return SOAResult(SOAResultType.FAILURE, providenceChainResult.message)
 

--- a/src/main/services/transaction/GetProvidenceChainService.kt
+++ b/src/main/services/transaction/GetProvidenceChainService.kt
@@ -11,13 +11,8 @@ import org.jetbrains.exposed.dao.EntityID
  *
  */
 object GetProvidenceChainService {
-    fun execute(transactionId: Int): SOAResult<TransactionList> {
-        // Get the transaction in question
-        val txResult = GetTransactionService.execute(transactionId)
+    fun execute(transaction: Transaction): SOAResult<TransactionList> {
         // TODO -- verify that the transaction is a token type
-        if (txResult.result != SOAResultType.SUCCESS)
-            return SOAResult(txResult.result, txResult.message, null)
-        var tx = txResult.data!!
         // verify no children exist
         // TODO we may not need this check
 //        var childrenResult = getChildren(tx.id)
@@ -27,7 +22,7 @@ object GetProvidenceChainService {
 //        if (childrenResult.data!!.any())
 //            return SOAResult(SOAResultType.FAILURE, "Must send a leaf node, must not have children", null)
 
-        val mainChain = getHistoricChain(tx)
+        val mainChain = getHistoricChain(transaction)
 
         return SOAResult(SOAResultType.SUCCESS, null, TransactionList(mainChain))
     }

--- a/src/main/services/transaction/GetProvidenceChainsService.kt
+++ b/src/main/services/transaction/GetProvidenceChainsService.kt
@@ -15,18 +15,13 @@ import main.daos.*
  *
  */
 object GetProvidenceChainsService {
-    fun execute(transactionId: Int) : SOAResult<List<TransactionList>> {
-        // Get the transaction in question
-        val txResult = GetTransactionService.execute(transactionId)
-        if(txResult.result != SOAResultType.SUCCESS)
-            return SOAResult(txResult.result, txResult.message, null)
-        var tx = txResult.data!!
+    fun execute(transaction: Transaction) : SOAResult<List<TransactionList>> {
         // Keep a map of all providence chains that we are populating
         var providenceChains = mutableMapOf<Int, MutableList<Transaction>>()
         // Once completed populating (no more children), a chain is moved to this list
         var providenceChainsFinal = mutableListOf<TransactionList>()
 
-        var mainChain = GetProvidenceChainService.getHistoricChain(tx)
+        var mainChain = GetProvidenceChainService.getHistoricChain(transaction)
 
         // Add the main chain to the temporary map of 'all chains that are in progress'
         providenceChains[mainChain.last().idValue] = mainChain

--- a/src/test/TestHelper.kt
+++ b/src/test/TestHelper.kt
@@ -29,7 +29,7 @@ object TestHelper {
      *
      * Returns [endTransactionId: ARYA6 ,sideTransactionId: ARYA4]
      */
-    fun buildGenericProvidenceChain(): List<EntityID<Int>> {
+    fun buildGenericProvidenceChain(): List<Transaction> {
         var action = ActionNamespace(
             type = ActionType.CREATE,
             data = 1,
@@ -55,7 +55,7 @@ object TestHelper {
             var transaction6Namespace = TransactionNamespace(from = "ARYA6", to = "MIKE6", action = action, previousTransaction = tx4.idValue, metadatas = metadatas)
             var tx5 = GenerateTransactionService.execute(transaction5Namespace).data!!
             var tx6 = GenerateTransactionService.execute(transaction6Namespace).data!!
-            return@transaction listOf(tx1.id, tx2.id, tx3.id, tx4.id, tx5.id, tx6.id)
+            return@transaction listOf(tx1, tx2, tx3, tx4, tx5, tx6)
         }
     }
 

--- a/src/test/unit/services/challenge/RedeemChallengeServiceTest.kt
+++ b/src/test/unit/services/challenge/RedeemChallengeServiceTest.kt
@@ -10,12 +10,13 @@ import kotlinserverless.framework.models.Handler
 import kotlinserverless.framework.services.SOAResultType
 import main.services.challenge.ActivateChallengeService
 import main.services.challenge.CompleteChallengeService
+import main.services.challenge.RedeemChallengeService
 import main.services.challenge.ShareChallengeService
 import org.jetbrains.exposed.sql.transactions.transaction
 import test.TestHelper
 
 @ExtendWith(MockKExtension::class)
-class CompleteChallengeServiceTest : WordSpec() {
+class RedeemChallengeServiceTest : WordSpec() {
     private lateinit var challenge: Challenge
     private lateinit var userAccount1: UserAccount
     private lateinit var userAccount2: UserAccount
@@ -43,7 +44,7 @@ class CompleteChallengeServiceTest : WordSpec() {
         // TODO test off chain
         // TODO test if multi-tx share fails midway
         "calling execute with valid data" should {
-            "should complete the challenge by changing the state and distributing rewards" {
+            "should distribute rewards" {
                 transaction {
                     ActivateChallengeService.execute(userAccount1, challenge.idValue)
 
@@ -85,7 +86,7 @@ class CompleteChallengeServiceTest : WordSpec() {
 
                     // user 2 should not be able to complete the challenge
 
-                    var result = CompleteChallengeService.execute(
+                    var result = RedeemChallengeService.execute(
                         userAccount1,
                         challenge,
                         userAccount2.cryptoKeyPair.publicKey
@@ -95,16 +96,14 @@ class CompleteChallengeServiceTest : WordSpec() {
 
                     // user 3 should be able to complete the challenge
                     // should generate 3 transactions paying out user 3,2,1
-                    var completionResult = CompleteChallengeService.execute(
+                    var redeemResult = RedeemChallengeService.execute(
                         userAccount1,
                         challenge,
                         userAccount3.cryptoKeyPair.publicKey
                     )
-                    completionResult.result shouldBe SOAResultType.SUCCESS
-                    val distributionResults = completionResult.data!!.transactions
+                    redeemResult.result shouldBe SOAResultType.SUCCESS
+                    val distributionResults = redeemResult.data!!.transactions
                     distributionResults.count() shouldBe 3
-                    val state = challenge.getLastStateChangeTransaction()!!
-                    state.action.type shouldBe ActionType.COMPLETE
                 }
             }
         }

--- a/src/test/unit/services/reward/DistributeRewardServiceTest.kt
+++ b/src/test/unit/services/reward/DistributeRewardServiceTest.kt
@@ -9,7 +9,9 @@ import io.mockk.junit5.MockKExtension
 import kotlinserverless.framework.models.Handler
 import kotlinserverless.framework.services.SOAResultType
 import main.daos.Audience
+import main.daos.Reward
 import main.daos.RewardTypeName
+import main.daos.Transaction
 import main.services.reward.DistributeRewardService
 import org.jetbrains.exposed.dao.EntityID
 import org.jetbrains.exposed.sql.transactions.transaction
@@ -18,8 +20,8 @@ import test.TestHelper
 
 @ExtendWith(MockKExtension::class)
 class DistributeRewardServiceTest : WordSpec() {
-    private lateinit var rewardId: EntityID<Int>
-    private lateinit var providenceChainIds: List<EntityID<Int>>
+    private lateinit var reward: Reward
+    private lateinit var providenceChainTxs: List<Transaction>
 
     override fun beforeTest(description: Description): Unit {
         Handler.connectAndBuildTables()
@@ -33,11 +35,11 @@ class DistributeRewardServiceTest : WordSpec() {
         "calling execute with a valid transfer" should {
             "generate a list of transactions transferring to the providence chain evenly" {
                 transaction {
-                    rewardId = TestHelper.buildGenericReward(null, Audience.PROVIDENCE, RewardTypeName.EVEN).id
-                    providenceChainIds = TestHelper.buildGenericProvidenceChain()
+                    reward = TestHelper.buildGenericReward(null, Audience.PROVIDENCE, RewardTypeName.EVEN)
+                    providenceChainTxs = TestHelper.buildGenericProvidenceChain()
 
                     val result = DistributeRewardService.execute(
-                        rewardId.value, providenceChainIds.last().value
+                        reward, providenceChainTxs.last()
                     )
 
                     result.result shouldBe SOAResultType.SUCCESS
@@ -63,11 +65,11 @@ class DistributeRewardServiceTest : WordSpec() {
 
             "generate a single transaction to one individual when reward type is single" {
                 transaction {
-                    rewardId = TestHelper.buildGenericReward(null, Audience.PROVIDENCE, RewardTypeName.SINGLE).id
-                    providenceChainIds = TestHelper.buildGenericProvidenceChain()
+                    reward = TestHelper.buildGenericReward(null, Audience.PROVIDENCE, RewardTypeName.SINGLE)
+                    providenceChainTxs = TestHelper.buildGenericProvidenceChain()
 
                     val result = DistributeRewardService.execute(
-                        rewardId.value, providenceChainIds.last().value
+                        reward, providenceChainTxs.last()
                     )
 
                     result.result shouldBe SOAResultType.SUCCESS
@@ -82,11 +84,11 @@ class DistributeRewardServiceTest : WordSpec() {
             }
             "generate a list of transactions transferring to the providence chain in n over 2" {
                 transaction {
-                    rewardId = TestHelper.buildGenericReward(null, Audience.PROVIDENCE, RewardTypeName.N_OVER_2).id
-                    providenceChainIds = TestHelper.buildGenericProvidenceChain()
+                    reward = TestHelper.buildGenericReward(null, Audience.PROVIDENCE, RewardTypeName.N_OVER_2)
+                    providenceChainTxs = TestHelper.buildGenericProvidenceChain()
 
                     val result = DistributeRewardService.execute(
-                        rewardId.value, providenceChainIds.last().value
+                        reward, providenceChainTxs.last()
                     )
 
                     result.result shouldBe SOAResultType.SUCCESS

--- a/src/test/unit/services/transaction/GetProvidenceChainServiceTest.kt
+++ b/src/test/unit/services/transaction/GetProvidenceChainServiceTest.kt
@@ -1,6 +1,5 @@
 package test.unit.services.transaction
 
-import framework.models.idValue
 import io.kotlintest.*
 import io.kotlintest.matchers.collections.shouldContainExactly
 import io.kotlintest.specs.WordSpec
@@ -8,21 +7,21 @@ import io.mockk.junit5.MockKExtension
 import org.junit.jupiter.api.extension.ExtendWith
 import kotlinserverless.framework.services.SOAResultType
 import kotlinserverless.framework.models.Handler
+import main.daos.Transaction
 import main.services.transaction.GetProvidenceChainService
-import org.jetbrains.exposed.dao.EntityID
 import org.jetbrains.exposed.sql.transactions.transaction
 import test.TestHelper
 
 @ExtendWith(MockKExtension::class)
 class GetProvidenceChainServiceTest : WordSpec() {
-    private lateinit var endTransactionId: EntityID<Int>
-    private lateinit var sideTransactionId: EntityID<Int>
+    private lateinit var endTransaction: Transaction
+    private lateinit var sideTransaction: Transaction
 
     override fun beforeTest(description: Description): Unit {
         Handler.connectAndBuildTables()
         val transactions = TestHelper.buildGenericProvidenceChain()
-        endTransactionId = transactions[5]
-        sideTransactionId = transactions[3]
+        endTransaction = transactions[5]
+        sideTransaction = transactions[3]
     }
 
     override fun afterTest(description: Description, result: TestResult) {
@@ -33,7 +32,7 @@ class GetProvidenceChainServiceTest : WordSpec() {
         "calling execute with a valid transaction id" should {
             "return the providence chain" {
                 transaction {
-                    val result = GetProvidenceChainService.execute(endTransactionId.value)
+                    val result = GetProvidenceChainService.execute(endTransaction)
 
                     result.result shouldBe SOAResultType.SUCCESS
 

--- a/src/test/unit/services/transaction/GetProvidenceChainsServiceTest.kt
+++ b/src/test/unit/services/transaction/GetProvidenceChainsServiceTest.kt
@@ -7,6 +7,7 @@ import io.mockk.junit5.MockKExtension
 import org.junit.jupiter.api.extension.ExtendWith
 import kotlinserverless.framework.services.SOAResultType
 import kotlinserverless.framework.models.Handler
+import main.daos.Transaction
 import main.services.transaction.GetProvidenceChainsService
 import org.jetbrains.exposed.dao.EntityID
 import org.jetbrains.exposed.sql.transactions.transaction
@@ -14,14 +15,14 @@ import test.TestHelper
 
 @ExtendWith(MockKExtension::class)
 class GetProvidenceChainsServiceTest : WordSpec() {
-    private lateinit var middleTransactionId: EntityID<Int>
-    private lateinit var sideTransactionId: EntityID<Int>
+    private lateinit var middleTransaction: Transaction
+    private lateinit var sideTransaction: Transaction
 
     override fun beforeTest(description: Description): Unit {
         Handler.connectAndBuildTables()
         val transactions = TestHelper.buildGenericProvidenceChain()
-        sideTransactionId = transactions[2]
-        middleTransactionId = transactions[1]
+        sideTransaction = transactions[2]
+        middleTransaction = transactions[1]
     }
 
     override fun afterTest(description: Description, result: TestResult) {
@@ -32,7 +33,7 @@ class GetProvidenceChainsServiceTest : WordSpec() {
         "calling execute with a valid transaction id" should {
             "return the list of all possible chains if there are many children nodes involved" {
                 transaction {
-                    val result = GetProvidenceChainsService.execute(middleTransactionId.value)
+                    val result = GetProvidenceChainsService.execute(middleTransaction)
 
                     result.result shouldBe SOAResultType.SUCCESS
                     result.data!!.count() shouldBe 3
@@ -57,7 +58,7 @@ class GetProvidenceChainsServiceTest : WordSpec() {
             }
             "return a single chain if there are no children node involved" {
                 transaction {
-                    val result = GetProvidenceChainsService.execute(sideTransactionId.value)
+                    val result = GetProvidenceChainsService.execute(sideTransaction)
 
                     result.result shouldBe SOAResultType.SUCCESS
                     result.data!!.count() shouldBe 1


### PR DESCRIPTION
- Separate the redemption logic into it's own service
- Update completion service to use new redeem service
- Add some TODO work for future upgrades
- Update calls to be more efficient, passing in objects rather than id's for less DB calls
- Upgrade tests to be more encompassing