### PR TITLE
Cleanup the response body serializartion logic, remove basenamespace and baseintentyty to map in favor of a single interface

### DIFF
--- a/src/framework/models/DatabaseModels.kt
+++ b/src/framework/models/DatabaseModels.kt
@@ -1,8 +1,6 @@
 package framework.models
 
-import com.fasterxml.jackson.databind.ObjectMapper
 import org.jetbrains.exposed.dao.*
-import org.jetbrains.exposed.sql.transactions.transaction
 import org.joda.time.DateTime
 import org.joda.time.DateTimeZone
 
@@ -14,12 +12,12 @@ abstract class BaseIntIdTable(name: String) : IntIdTable(name) {
     val deletedAt = datetime("deletedAt").nullable()
 }
 
-abstract class BaseIntEntity(id: EntityID<Int>, table: BaseIntIdTable) : IntEntity(id) {
+abstract class BaseIntEntity(id: EntityID<Int>, table: BaseIntIdTable) : BaseObject, IntEntity(id) {
     val createdAt by table.createdAt
     var updatedAt by table.updatedAt
     var deletedAt by table.deletedAt
 
-    open fun toMap(): MutableMap<String, Any?> {
+    override fun toMap(): MutableMap<String, Any?> {
         return mutableMapOf(
             Pair("id", idValue),
             Pair("createdAt", createdAt.toString()),
@@ -29,8 +27,8 @@ abstract class BaseIntEntity(id: EntityID<Int>, table: BaseIntIdTable) : IntEnti
     }
 }
 
-abstract class BaseNamespace {
-    abstract fun toMap(): MutableMap<String, Any?>
+interface BaseObject {
+    fun toMap(): MutableMap<String, Any?>
 }
 
 abstract class BaseIntEntityClass<E : BaseIntEntity>(table: BaseIntIdTable) : IntEntityClass<E>(table) {

--- a/src/framework/models/Handler.kt
+++ b/src/framework/models/Handler.kt
@@ -4,8 +4,6 @@ import kotlinserverless.framework.models.ApiGatewayResponse.Companion.LOG
 import kotlinserverless.framework.dispatchers.RequestDispatcher
 import com.amazonaws.services.lambda.runtime.Context
 import com.amazonaws.services.lambda.runtime.RequestHandler
-import framework.models.BaseIntEntity
-import framework.models.BaseNamespace
 import main.daos.*
 import org.apache.log4j.BasicConfigurator
 import org.apache.log4j.Logger
@@ -64,14 +62,7 @@ open class Handler: RequestHandler<Map<String, Any>, ApiGatewayResponse> {
     finally {
       return ApiGatewayResponse.build {
         statusCode = status
-        if (body is BaseIntEntity)
-          objectBody = body
-        else if (body is Collection<*>)
-          listBody = body as List<Any>
-        else {
-          rawBody = body
-        }
-        headers = mapOf("X-Powered-By" to "AWS Lambda & Serverless")
+        rawBody = body
       }
     }
   }

--- a/src/main/daos/Challenge.kt
+++ b/src/main/daos/Challenge.kt
@@ -188,7 +188,7 @@ class Challenge(id: EntityID<Int>) : BaseIntEntity(id, Challenges) {
 
 class ChallengeList(
     val challenges: List<Challenge>
-): BaseNamespace() {
+): BaseObject {
     override fun toMap(): MutableMap<String, Any?> {
         var map = mutableMapOf<String, Any?>()
         map.put("challenges", challenges.map { it.toMap() })
@@ -196,7 +196,7 @@ class ChallengeList(
     }
 }
 
-class ChallengeToUnsharedTransaction(val challenge: Challenge, val shareTransactionList: ShareTransactionList): BaseNamespace() {
+class ChallengeToUnsharedTransaction(val challenge: Challenge, val shareTransactionList: ShareTransactionList): BaseObject {
     override fun toMap(): MutableMap<String, Any?> {
         var map = mutableMapOf<String, Any?>()
         map.put("challenge", challenge.toMap())
@@ -207,7 +207,7 @@ class ChallengeToUnsharedTransaction(val challenge: Challenge, val shareTransact
 
 data class ChallengeToUnsharedTransactionNamespace(val challenge: ChallengeNamespace, val shareTransactionList: ShareTransactionListNamespace)
 
-class ChallengeToUnsharedTransactionsList(val challengeToUnsharedTransactions: List<ChallengeToUnsharedTransaction>): BaseNamespace() {
+class ChallengeToUnsharedTransactionsList(val challengeToUnsharedTransactions: List<ChallengeToUnsharedTransaction>): BaseObject {
     override fun toMap(): MutableMap<String, Any?> {
         var map = mutableMapOf<String, Any?>()
         map.put("challengeToUnsharedTransactions", challengeToUnsharedTransactions.map { it.toMap() })
@@ -217,7 +217,7 @@ class ChallengeToUnsharedTransactionsList(val challengeToUnsharedTransactions: L
 
 data class ChallengeToUnsharedTransactionsNamespaceList(val challengeToUnsharedTransactions: List<ChallengeToUnsharedTransactionNamespace>)
 
-class EmailToChallengeBalanceList(val challengeId: Int, val emailToChallengeBalances: MutableMap<String, Int>): BaseNamespace() {
+class EmailToChallengeBalanceList(val challengeId: Int, val emailToChallengeBalances: MutableMap<String, Int>): BaseObject {
     override fun toMap(): MutableMap<String, Any?> {
         var map = mutableMapOf<String, Any?>()
         map.put("challengeId", challengeId)

--- a/src/main/daos/Transaction.kt
+++ b/src/main/daos/Transaction.kt
@@ -52,7 +52,7 @@ object TransactionsMetadata : Table("transactions_to_metadatas") {
 
 data class TransactionNamespace(val from: String?=null, val to: String?=null, val action: ActionNamespace?=null, val previousTransaction: Int?=null, val metadatas: Array<MetadatasNamespace>? = null)
 
-class TransactionList(val transactions: List<Transaction>): BaseNamespace() {
+class TransactionList(val transactions: List<Transaction>): BaseObject {
     override fun toMap(): MutableMap<String, Any?> {
         var map = mutableMapOf<String, Any?>()
         map.put("transactions", transactions.map { it.toMap() })
@@ -62,7 +62,7 @@ class TransactionList(val transactions: List<Transaction>): BaseNamespace() {
 
 data class TransactionNamespaceList(val transactions: List<TransactionNamespace>)
 
-class TransactionToShare(val transaction: Transaction, val shares: Int): BaseNamespace() {
+class TransactionToShare(val transaction: Transaction, val shares: Int): BaseObject {
     override fun toMap(): MutableMap<String, Any?> {
         var map = mutableMapOf<String, Any?>()
         map.put("transaction", transaction.toMap())
@@ -73,7 +73,7 @@ class TransactionToShare(val transaction: Transaction, val shares: Int): BaseNam
 
 data class TransactionToShareNamespace(val transaction: TransactionNamespace, val shares: Int)
 
-class ShareTransactionList(val transactionsToShares: List<TransactionToShare>): BaseNamespace() {
+class ShareTransactionList(val transactionsToShares: List<TransactionToShare>): BaseObject {
     override fun toMap(): MutableMap<String, Any?> {
         var map = mutableMapOf<String, Any?>()
         map.put("transactionsToShares", transactionsToShares.map { it.toMap() })
@@ -86,7 +86,7 @@ data class ShareTransactionListNamespace(val transactionsToShares: List<Transact
 class TransactionWithNewUser(
     val transactions: List<Transaction>,
     val newUser: NewUserAccount? = null
-): BaseNamespace() {
+): BaseObject {
     override fun toMap(): MutableMap<String, Any?> {
         var map = mutableMapOf<String, Any?>()
         map.put("transactions", transactions.map { it.toMap() })

--- a/src/main/daos/UserAccount.kt
+++ b/src/main/daos/UserAccount.kt
@@ -3,7 +3,7 @@ package main.daos
 import framework.models.BaseIntEntity
 import framework.models.BaseIntEntityClass
 import framework.models.BaseIntIdTable
-import framework.models.BaseNamespace
+import framework.models.BaseObject
 import org.jetbrains.exposed.dao.*
 
 /**
@@ -50,7 +50,7 @@ class NewUserAccount(
         val value: UserAccount,
         val privateKey: String,
         val secretKey: String
-): BaseNamespace() {
+): BaseObject {
     override fun toMap(): MutableMap<String, Any?> {
         val map = mutableMapOf<String, Any?>()
         map.put("value", value.toMap())


### PR DESCRIPTION
- Cleanup ApiGatewayResponse to be much more slim and efficient
- Refactor toMap to be in a single interface for all objects/namespaces
- Only use a transaction when necessary when populating the response