### PR TITLE
changes get requests to pass IDs thru as query params

### DIFF
--- a/docs/API Reference.md
+++ b/docs/API Reference.md
@@ -2,14 +2,14 @@ Table of Contents
 
 1. [User APIs](#user-apis)
    + [Find One User](#find-one-user)
-   + [Get User Balances](#get-user-balances)
+   + [GET (requestData object must pass data in as query parameters instead of request body) User Balances](#GET (requestData object must pass data in as query parameters instead of request body)-user-balances)
    + [Create User](#user-create)
    + [Login](#login)
    + [Logout](#logout)
 1. [Challenge APIs](#challenge-apis)
    + [Find One Challenge](#find-one-challenge)
    + [Find All Challenges](#find-all-challenges)
-   + [Get All Balances For a Challenge](#get-all-balances-for-a-challenge)
+   + [GET (requestData object must pass data in as query parameters instead of request body) All Balances For a Challenge](#GET (requestData object must pass data in as query parameters instead of request body)-all-balances-for-a-challenge)
    + [Create Challenge](#create-challenge)
    + [Share Challenge](#share-challenge)
    + [Redeem Challenge](#redeem-challenge)
@@ -56,7 +56,7 @@ This API is a simple retrieval for a single user account
 
 #### Method
 
-GET
+GET (requestData object must pass data in as query parameters instead of request body)
 
 #### Parameters
 
@@ -121,7 +121,7 @@ GET
 }
 ```
 
-## Get User Balances
+## GET (requestData object must pass data in as query parameters instead of request body) User Balances
 
 This API will return all of the caller's balances for each challenge that they have participated in
 
@@ -131,7 +131,7 @@ This API will return all of the caller's balances for each challenge that they h
 
 #### Method
 
-GET
+GET (requestData object must pass data in as query parameters instead of request body)
 
 #### Parameters
 
@@ -149,7 +149,7 @@ GET
 {
   "statusCode" : 200,
   "body" : {
-    "challengeToUnsharedTransactions" : [ {
+    "challenGET (requestData object must pass data in as query parameters instead of request body)oUnsharedTransactions" : [ {
       "challenge" : {
         "createdAt" : "2019-01-23T13:55:04.401-08:00",
         "updatedAt" : "null",
@@ -936,7 +936,7 @@ This API is called in order to retrieve the data for a single challenge
 
 #### Method
 
-GET
+GET (requestData object must pass data in as query parameters instead of request body)
 
 #### Parameters
 
@@ -1062,7 +1062,7 @@ This API is called in order to retrieve the data for all challenges for the call
 
 #### Method
 
-GET
+GET (requestData object must pass data in as query parameters instead of request body)
 
 #### Parameters
 
@@ -1451,7 +1451,7 @@ GET
 }
 ```
 
-## Get All Balances For a Challenge
+## GET (requestData object must pass data in as query parameters instead of request body) All Balances For a Challenge
 
 This API is called by a challenge sponsor in order to retrieve all balances being held by other users on that challenge
 
@@ -1461,7 +1461,7 @@ This API is called by a challenge sponsor in order to retrieve all balances bein
 
 #### Method
 
-GET
+GET (requestData object must pass data in as query parameters instead of request body)
 
 #### Parameters
 

--- a/src/framework/controllers/Controller.kt
+++ b/src/framework/controllers/Controller.kt
@@ -32,8 +32,8 @@ interface Controller<M> {
         return when(method) {
             ControllerHelper.HTTP_GET -> {
                 when {
-                    requestData.body.containsKey("id") -> {
-                        val id = requestData.body["id"].toString().toIntOrNull()
+                    requestData.queryParams.containsKey("id") -> {
+                        val id = requestData.queryParams["id"].toString().toIntOrNull()
 
                         id ?: throw Exception("Id must be an integer")
                         restController.findOne(user, requestData, id.toString().toInt())

--- a/src/framework/dispatchers/RequestDispatcher.kt
+++ b/src/framework/dispatchers/RequestDispatcher.kt
@@ -64,7 +64,7 @@ open class RequestDispatcher: Dispatcher<ApiGatewayRequest, Any> {
     fun findUserByRequest(requestData: ControllerHelper.RequestData) : UserAccount? {
         return GetUserAccountService.execute(
             requestData.queryParams["userId"]?.toString()?.toInt(),
-            requestData.body["email"]?.toString(),
+            requestData.queryParams["email"]?.toString(),
             requestData.userAuth?.apiKey
         ).data
     }

--- a/src/framework/dispatchers/RequestDispatcher.kt
+++ b/src/framework/dispatchers/RequestDispatcher.kt
@@ -63,7 +63,7 @@ open class RequestDispatcher: Dispatcher<ApiGatewayRequest, Any> {
 
     fun findUserByRequest(requestData: ControllerHelper.RequestData) : UserAccount? {
         return GetUserAccountService.execute(
-            requestData.body["userId"]?.toString()?.toInt(),
+            requestData.queryParams["userId"]?.toString()?.toInt(),
             requestData.body["email"]?.toString(),
             requestData.userAuth?.apiKey
         ).data

--- a/src/main/controllers/ChallengeController.kt
+++ b/src/main/controllers/ChallengeController.kt
@@ -114,7 +114,7 @@ class ChallengeController: DefaultController<Challenge>(), RestController<Challe
     fun balances(user: UserAccount?, requestData: RequestData): SOAResult<EmailToChallengeBalanceList> {
         validateApiKey(user!!, requestData)
 
-        val challengeId = requestData.body["challengeId"] as Int
+        val challengeId = requestData.queryParams["challengeId"] as Int
 
         val getAllBalancesForChallengeResult = GetAllBalancesForChallengeService.execute(user, challengeId)
 

--- a/src/test/TestHelper.kt
+++ b/src/test/TestHelper.kt
@@ -20,12 +20,14 @@ import org.joda.time.DateTimeZone
 object TestHelper {
 
     // Used to generate a request to the api, used for integration testing
-    fun buildRequest(user: NewUserAccount?, path: String, httpMethod: String, body: Map<String, Any>? = null): Map<String, Any> {
+    fun buildRequest(user: NewUserAccount?, path: String, httpMethod: String, body: Map<String, Any>? = null, queryParams: Map<String, Any>? = null): Map<String, Any> {
         var request = mutableMapOf<String, Any>()
         request["path"] = path
         request["httpMethod"] = httpMethod
         if(body != null)
             request["body"] = body
+        if(queryParams != null)
+            request["queryStringParameters"] = queryParams
         if(user != null)
             request["headers"] = mapOf(Pair("Authorization", UserAccountHelper.getUserAuth(user)))
         return request

--- a/src/test/integration/handlers/challenge/CompleteChallengeTest.kt
+++ b/src/test/integration/handlers/challenge/CompleteChallengeTest.kt
@@ -57,9 +57,11 @@ class CompleteChallengeTest : WordSpec() {
                         "/challenge/complete",
                         "PATCH",
                         mapOf(
-                            Pair("userId", user1.value.idValue.toString()),
                             Pair("challengeId", challenge.idValue),
                             Pair("completerPublicKey", user2.value.cryptoKeyPair.publicKey)
+                        ),
+                        mapOf(
+                            Pair("userId", user1.value.idValue.toString())
                         )
                     )
 
@@ -78,9 +80,11 @@ class CompleteChallengeTest : WordSpec() {
                         "/challenge/complete",
                         "PATCH",
                         mapOf(
-                                Pair("userId", user2.value.idValue.toString()),
-                                Pair("challengeId", challenge.idValue),
-                                Pair("completerPublicKey", user2.value.cryptoKeyPair.publicKey)
+                            Pair("challengeId", challenge.idValue),
+                            Pair("completerPublicKey", user2.value.cryptoKeyPair.publicKey)
+                        ),
+                        mapOf(
+                            Pair("userId", user2.value.idValue.toString())
                         )
                     )
 
@@ -96,9 +100,11 @@ class CompleteChallengeTest : WordSpec() {
                         "/challenge/complete",
                         "PATCH",
                         mapOf(
-                            Pair("userId", user1.value.idValue.toString()),
                             Pair("challengeId", notActivatedChallenge.idValue),
                             Pair("completerPublicKey", user2.value.cryptoKeyPair.publicKey)
+                        ),
+                        mapOf(
+                            Pair("userId", user1.value.idValue.toString())
                         )
                     )
 
@@ -117,9 +123,11 @@ class CompleteChallengeTest : WordSpec() {
                         "/challenge/redeem",
                         "PATCH",
                         mapOf(
-                            Pair("userId", user1.value.idValue.toString()),
                             Pair("challengeId", challenge.idValue),
                             Pair("completerPublicKey", user2.value.cryptoKeyPair.publicKey)
+                        ),
+                        mapOf(
+                            Pair("userId", user1.value.idValue.toString())
                         )
                     )
 
@@ -138,11 +146,14 @@ class CompleteChallengeTest : WordSpec() {
                         "/challenge/complete",
                         "PATCH",
                         mapOf(
-                            Pair("userId", user2.value.idValue.toString()),
                             Pair("challengeId", challenge.idValue),
                             Pair("completerPublicKey", user2.value.cryptoKeyPair.publicKey)
+                        ),
+                        mapOf(
+                            Pair("userId", user2.value.idValue.toString())
                         )
                     )
+
 
                     val redeemChallengeResult = handler.handleRequest(map, contxt)
                     redeemChallengeResult.statusCode shouldBe 403
@@ -156,9 +167,11 @@ class CompleteChallengeTest : WordSpec() {
                         "/challenge/redeem",
                         "PATCH",
                         mapOf(
-                            Pair("userId", user1.value.idValue.toString()),
                             Pair("challengeId", notActivatedChallenge.idValue),
                             Pair("completerPublicKey", user2.value.cryptoKeyPair.publicKey)
+                        ),
+                        mapOf(
+                            Pair("userId", user1.value.idValue.toString())
                         )
                     )
 

--- a/src/test/integration/handlers/challenge/FindAllBalancesForChallengeTest.kt
+++ b/src/test/integration/handlers/challenge/FindAllBalancesForChallengeTest.kt
@@ -57,8 +57,10 @@ class FindAllBalancesForChallengeTest : WordSpec() {
                             "/challenge/balances",
                             "GET",
                             mapOf(
-                                    Pair("userId", user1.value.idValue.toString()),
                                     Pair("challengeId", challenge.idValue)
+                            ),
+                            mapOf(
+                                    Pair("userId", user1.value.idValue.toString())
                             )
                     )
 
@@ -84,8 +86,10 @@ class FindAllBalancesForChallengeTest : WordSpec() {
                             "/challenge/balances",
                             "GET",
                             mapOf(
-                                    Pair("userId", user2.value.idValue.toString()),
                                     Pair("challengeId", challenge.idValue)
+                            ),
+                            mapOf(
+                                    Pair("userId", user2.value.idValue.toString())
                             )
                     )
 

--- a/src/test/integration/handlers/challenge/FindAllBalancesForChallengeTest.kt
+++ b/src/test/integration/handlers/challenge/FindAllBalancesForChallengeTest.kt
@@ -56,11 +56,11 @@ class FindAllBalancesForChallengeTest : WordSpec() {
                             user1,
                             "/challenge/balances",
                             "GET",
+                            null,
                             mapOf(
+                                    Pair("userId", user1.value.idValue.toString()),
                                     Pair("challengeId", challenge.idValue)
-                            ),
-                            mapOf(
-                                    Pair("userId", user1.value.idValue.toString())
+
                             )
                     )
 
@@ -85,11 +85,10 @@ class FindAllBalancesForChallengeTest : WordSpec() {
                             user2,
                             "/challenge/balances",
                             "GET",
+                            null,
                             mapOf(
+                                    Pair("userId", user2.value.idValue.toString()),
                                     Pair("challengeId", challenge.idValue)
-                            ),
-                            mapOf(
-                                    Pair("userId", user2.value.idValue.toString())
                             )
                     )
 

--- a/src/test/integration/handlers/challenge/FindAllChallengesTest.kt
+++ b/src/test/integration/handlers/challenge/FindAllChallengesTest.kt
@@ -38,6 +38,7 @@ class FindAllChallengesTest : WordSpec() {
                     user1,
                     "/challenge/findAll",
                     "GET",
+                    null,
                     mapOf(
                             Pair("userId", user1.value.idValue.toString())
                     )
@@ -46,6 +47,7 @@ class FindAllChallengesTest : WordSpec() {
                     user2,
                     "/challenge/findAll",
                     "GET",
+                    null,
                     mapOf(
                             Pair("userId", user2.value.idValue.toString())
                     )

--- a/src/test/integration/handlers/challenge/FindOneChallengeTest.kt
+++ b/src/test/integration/handlers/challenge/FindOneChallengeTest.kt
@@ -36,6 +36,7 @@ class FindOneChallengeTest : WordSpec() {
                 user,
                 "/challenge",
                 "GET",
+                    null,
                 mapOf(
                     Pair("id", user.value.idValue)
                 )
@@ -44,6 +45,7 @@ class FindOneChallengeTest : WordSpec() {
                 user,
                 "/challenge",
                 "GET",
+                    null,
                 mapOf(
                     Pair("id", 404)
                 )

--- a/src/test/integration/handlers/challenge/ShareChallengeTest.kt
+++ b/src/test/integration/handlers/challenge/ShareChallengeTest.kt
@@ -40,11 +40,13 @@ class ShareChallengeTest : WordSpec() {
                 "/challenge/share",
                 "PATCH",
                 mapOf(
-                    Pair("userId", user1.value.idValue.toString()),
                     Pair("challengeId", challenge.idValue),
                     Pair("publicKeyToShareWith", user2.value.cryptoKeyPair.publicKey),
                     Pair("shares", 3),
                     Pair("emailToShareWith", user2.value.userMetadata.email)
+                ),
+                mapOf(
+                    Pair("userId", user1.value.idValue.toString())
                 )
             )
             newUserMap = TestHelper.buildRequest(
@@ -52,23 +54,27 @@ class ShareChallengeTest : WordSpec() {
                 "/challenge/share",
                 "PATCH",
                 mapOf(
-                    Pair("userId", user1.value.idValue.toString()),
                     Pair("challengeId", challenge.idValue),
                     Pair("emailToShareWith", "test@test.com"),
                     Pair("shares", 3)
-                )
+                ),
+                    mapOf(
+                            Pair("userId", user1.value.idValue.toString())
+                    )
             )
             tooManySharesMap = TestHelper.buildRequest(
                 user1,
                 "/challenge/share",
                 "PATCH",
                 mapOf(
-                    Pair("userId", user1.value.idValue.toString()),
                     Pair("challengeId", challenge.idValue),
                     Pair("publicKeyToShareWith", user2.value.cryptoKeyPair.publicKey),
                     Pair("emailToShareWith", user2.value.userMetadata.email),
                     Pair("shares", 1000)
-                )
+                ),
+                    mapOf(
+                            Pair("userId", user1.value.idValue.toString())
+                    )
             )
         }
     }

--- a/src/test/integration/handlers/user_account/FindAllChallengeBalancesTest.kt
+++ b/src/test/integration/handlers/user_account/FindAllChallengeBalancesTest.kt
@@ -38,6 +38,7 @@ class FindAllChallengeBalancesTest : WordSpec() {
                 user1,
                 "/user/balances",
                 "GET",
+                    null,
                 mapOf(
                     Pair("userId", user1.value.idValue.toString())
                 )
@@ -46,6 +47,7 @@ class FindAllChallengeBalancesTest : WordSpec() {
                 user2,
                 "/user/balances",
                 "GET",
+                    null,
                 mapOf(
                     Pair("userId", user2.value.idValue.toString())
                 )

--- a/src/test/integration/handlers/user_account/GetUserAccountTest.kt
+++ b/src/test/integration/handlers/user_account/GetUserAccountTest.kt
@@ -45,6 +45,7 @@ class GetUserAccountTest : WordSpec() {
                 user1,
                 "/user",
                 "GET",
+                    null,
                 mapOf(
                         Pair("id", user1.value.idValue),
                         Pair("userId", user1.value.idValue.toString())

--- a/src/test/integration/handlers/user_account/UserAccountLoginTest.kt
+++ b/src/test/integration/handlers/user_account/UserAccountLoginTest.kt
@@ -33,9 +33,11 @@ class UserAccountLoginTest : WordSpec() {
                 "/user/login",
                 "PATCH",
                 mapOf(
-                    Pair("userId", user.value.idValue),
                     Pair("firstname", "dev"),
                     Pair("lastname", "ncnt")
+                ),
+                mapOf(
+                    Pair("userId", user.value.idValue.toString())
                 )
             )
         }

--- a/src/test/integration/handlers/user_account/UserAccountLogoutTest.kt
+++ b/src/test/integration/handlers/user_account/UserAccountLogoutTest.kt
@@ -34,9 +34,11 @@ class UserAccountLogoutTest : WordSpec() {
                 "/user/logout",
                 "PATCH",
                 mapOf(
-                    Pair("userId", user.value.idValue),
                     Pair("firstname", "dev"),
                     Pair("lastname", "ncnt")
+                ),
+                mapOf(
+                    Pair("userId", user.value.idValue.toString())
                 )
             )
         }

--- a/src/test/integration/handlers/user_account/UserAccountResetTest.kt
+++ b/src/test/integration/handlers/user_account/UserAccountResetTest.kt
@@ -33,9 +33,11 @@ class UserAccountResetTest : WordSpec() {
                     "/user/reset",
                     "PATCH",
                     mapOf(
-                            Pair("userId", user.value.idValue),
                             Pair("firstname", "dev"),
                             Pair("lastname", "ncnt")
+                    ),
+                    mapOf(
+                            Pair("userId", user.value.idValue.toString())
                     )
             )
         }


### PR DESCRIPTION
this change covers all GET requests for the API and requires all "ID" parameters to be passed in as query parameters rather than as values in the request body